### PR TITLE
Allows to pass an array of normalizers in "with" option

### DIFF
--- a/lib/normalizr.rb
+++ b/lib/normalizr.rb
@@ -38,6 +38,7 @@ module Normalizr
   end
 
   def normalize(obj, *normalizers)
+    normalizers.flatten!
     normalizers = configuration.default_normalizers if normalizers.empty?
     normalizers.each do |name|
       name, options = name.first if Hash === name

--- a/spec/lib/normalizr_spec.rb
+++ b/spec/lib/normalizr_spec.rb
@@ -119,5 +119,24 @@ describe Normalizr do
         end
       end
     end
+    context 'normalizers are an array' do
+      let(:normalizers) { [[:strip, { truncate: { length: 8, omission: '...' }}, proc { |v| v.first(6) }]] }
+
+      context 'string' do
+        let(:value) { ' Lorem ipsum dolor sit amet' }
+
+        it 'strips, truncates and then slices the value' do
+          expect(subject).to eq('Lorem.')
+        end
+      end
+
+      context 'array' do
+        let(:value) { [' Lorem ipsum dolor sit amet', '    One more sentence'] }
+
+        it 'strips, truncates and then slices the value' do
+          expect(subject).to eq(['Lorem.', 'One m.'])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary ##

Allows to pass an array of normalizers in `with:` as in:

```ruby
normalize :attr_1, :attr2, with: [:downcase, :strip, :blank]
```